### PR TITLE
Fix to fail to obtain ip when docker machine running on

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -15,6 +15,7 @@ import (
 )
 
 var (
+	ipRegex   = regexp.MustCompile(`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`)
 	portRegex = regexp.MustCompile(`([0-9]+)\/(.+?)\s\->.+?:([0-9]+)`)
 )
 
@@ -42,18 +43,18 @@ func Run(image string, args ...string) *Container {
 		log.Fatalf("failed get ports image:%s", image)
 	}
 
-	host := "127.0.0.1"
+	c := &Container{
+		containerID: containerID,
+		image:       image,
+	}
 
+	host := "127.0.0.1"
 	// for docker-machine
 	if os.Getenv("DOCKER_HOST") != "" {
 		host = os.Getenv("DOCKER_HOST")
 	}
+	c.parseIp(host)
 
-	c := &Container{
-		containerID: containerID,
-		image:       image,
-		host:        host,
-	}
 	c.parsePorts(ports)
 	return c
 }
@@ -182,4 +183,9 @@ func (c *Container) parsePorts(lines string) {
 		c.networks[p1] = match[2]
 	}
 
+}
+
+func (c *Container) parseIp(ip string) {
+	fnd := ipRegex.FindString(ip)
+	c.host = fnd
 }

--- a/docker_test.go
+++ b/docker_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"os"
+	"regexp"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,11 +37,18 @@ func TestRun(t *testing.T) {
 	con := Run("redis")
 	defer con.Close()
 
-	require.Equal(t, "127.0.0.1", con.Host())
+	ip := "127.0.0.1"
+	// for docker-machine
+	if host := os.Getenv("DOCKER_HOST"); host != "" {
+		ipRegex := regexp.MustCompile(`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`)
+		ip = ipRegex.FindString(host)
+	}
+
+	require.Equal(t, ip, con.Host())
 
 	port := con.ports[6379]
 
-	require.Equal(t, net.JoinHostPort("127.0.0.1", strconv.Itoa(port)), con.Addr(6379))
+	require.Equal(t, net.JoinHostPort(ip, strconv.Itoa(port)), con.Addr(6379))
 	require.Equal(t, port, con.Port(6379))
 
 }
@@ -61,4 +71,16 @@ func TestWaitHTTP(t *testing.T) {
 	p := con.WaitHTTP(80, "/", 1*time.Second)
 	require.NotZero(t, p)
 
+}
+
+func TestParseIp(t *testing.T) {
+	c := Container{}
+
+	c.parseIp("127.0.0.1")
+	require.NotNil(t, c.host)
+	require.Equal(t, "127.0.0.1", c.host)
+
+	c.parseIp("tcp://192.168.99.100:2376")
+	require.NotNil(t, c.host)
+	require.Equal(t, "192.168.99.100", c.host)
 }


### PR DESCRIPTION
The environment variable "DOCKER_HOST" contains not only IP address but also a protocol and a port number. So tests fail on docker machine like below.

```
$ go test
--- FAIL: TestRun (0.45s)
        Error Trace:    docker_test.go:37
    Error:      Not equal: "127.0.0.1" (expected)
                    != "tcp://192.168.99.100:2376" (actual)
```

I modified to try.
- Add fucntion to parse IP addres.
- Modify TestRun function to pass test on docker machine.
  - It maybe an ad hoc..., because of same logic in production code.

Would you check or fix issue ?
